### PR TITLE
feat: aggiunge info PNRR e logo nel tab Scarica

### DIFF
--- a/dialog.py
+++ b/dialog.py
@@ -211,7 +211,7 @@ class AnncsuDialog(QDialog):
         lay.addWidget(sep)
 
         lbl_pnrr = QLabel(
-            '<p align="center" style="font-size:22px; color:gray;">'
+            '<p align="center" style="font-size:15px; color:gray;">'
             'Progetto finanziato nell\'ambito del '
             '<a href="https://www.italiadomani.gov.it/">PNRR</a>'
             ' — Missione 1, Componente 1, Investimento 1.3 '


### PR DESCRIPTION
## Summary

- Aggiunge `pnrr_logo.png` (logo ufficiale PNRR, 377×130 px) scaricato dall'issue
- Aggiunge nel tab "⬇ Scarica" il testo centrato con link cliccabili a PNRR, Misura 1.3.1 e sito ANNCSU

Closes #1

## Test plan

- [ ] Aprire il plugin in QGIS
- [ ] Verificare che nel tab "Scarica" compaia il logo PNRR centrato
- [ ] Verificare che il testo con i link sia centrato e i link si aprano nel browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)