### PR TITLE
fix: normalizza separatori di percorso su Windows

### DIFF
--- a/dialog.py
+++ b/dialog.py
@@ -451,7 +451,7 @@ class AnncsuDialog(QDialog):
         d = self.txt_download_dir.text().strip()
         n = self.txt_nome_file.text().strip()
         if d and n:
-            self.lbl_download_path.setText(os.path.join(d, n))
+            self.lbl_download_path.setText(os.path.join(d, n).replace("\\", "/"))
         else:
             self.lbl_download_path.setText("")
 
@@ -463,7 +463,7 @@ class AnncsuDialog(QDialog):
                                 "Specifica la cartella di destinazione e il nome del file.")
             return
 
-        dest_path = os.path.join(dest_dir, nome_file)
+        dest_path = os.path.join(dest_dir, nome_file).replace("\\", "/")
         if os.path.exists(dest_path):
             QMessageBox.warning(
                 self, "File esistente",


### PR DESCRIPTION
## Problema

Chiude #11.

Su Windows, `os.path.join("F:/TEMP", "file.parquet")` produce `F:/TEMP\file.parquet` (backslash), generando un percorso misto che QGIS non riconosce. Di conseguenza il campo **File ParquetANNCSU** non veniva auto-popolato al termine del download.

## Fix

Aggiunto `.replace("\\", "/")` in due punti di `dialog.py`:

- `_aggiorna_preview_download()` — etichetta di anteprima percorso (label arancione)
- `_avvia_download()` — `dest_path` passato al worker e restituito in `_on_download_completato`

Su Linux il replace è no-op (nessun backslash prodotto).

## Test

| OS | Comportamento atteso | Risultato |
|----|----------------------|-----------|
| Windows | `F:/TEMP/file.parquet` in label + auto-populate campo | ✓ |
| Linux | `/home/user/file.parquet` invariato | ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)